### PR TITLE
Add unit test for confidence interval extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,3 +95,10 @@ dvc repro
 ```
 
 This runs all the simulations and applies the methods for each of them. Outputs raw simulation data and estimates to `results` folder.
+
+### 3.4 Run tests
+
+```bash
+pytest
+```
+

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -1,0 +1,28 @@
+import pytest
+import pandas as pd
+import numpy as np
+import statsmodels.formula.api as smf
+
+from src.evaluate import autoregression
+
+
+def test_autoregression_confidence_interval_matches_statsmodels():
+    np.random.seed(0)
+    n = 20
+    df = pd.DataFrame({
+        "pre_experiment": np.random.normal(size=n),
+        "post_experiment": np.random.normal(size=n),
+        "is_treatment": [0, 1] * (n // 2),
+        "covariate": np.random.normal(size=n),
+    })
+
+    # Results from library function
+    results = autoregression(df, covariate=True)
+
+    # Fit the same model directly
+    formula = "post_experiment ~ pre_experiment + is_treatment + covariate"
+    model = smf.ols(formula, data=df).fit()
+    ci = model.conf_int().loc["is_treatment"]
+
+    assert results["ci_lower"] == pytest.approx(ci[0])
+    assert results["ci_upper"] == pytest.approx(ci[1])


### PR DESCRIPTION
## Summary
- add simple autoregression test verifying confidence interval handling
- note test execution in README

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68433a049c608320af7d38f619abafca